### PR TITLE
Add ZooKeeper port forwarding to Vagrant config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,6 +23,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     override.vm.network :forwarded_port, guest: 5050, host: 5050
     override.vm.network :forwarded_port, guest: 5051, host: 5051
     override.vm.network :forwarded_port, guest: 8080, host: 8080
+    override.vm.network :forwarded_port, guest: 2181, host: 2181
   end
   config.vm.provision 'shell', path: 'provision.sh', run: 'once'
 end


### PR DESCRIPTION
Adding an additional port forward so that you can run the Riak scheduler outside the VM and still let it store metadata in the copy of ZK running under Vagrant.
